### PR TITLE
Add light/dark theme toggle and improve navigation bar behavior

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,6 +95,7 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
       alias: {
         '@components': path.resolve(__dirname, 'src/components'),
         '@config': path.resolve(__dirname, 'src/config'),
+        '@context': path.resolve(__dirname, 'src/context'),
         '@fonts': path.resolve(__dirname, 'src/fonts'),
         '@hooks': path.resolve(__dirname, 'src/hooks'),
         '@images': path.resolve(__dirname, 'src/images'),

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,0 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/ssr-apis/
- */
-
- // You can delete this file if you're not using it

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "browserslist": "> 0.25%, not dead",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0 -p 8080",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -11,6 +11,8 @@ export { default as IconInstagram } from './instagram';
 export { default as IconLinkedin } from './linkedin';
 export { default as IconLoader } from './loader';
 export { default as IconLogo } from './logo';
+export { default as IconMoon } from './moon';
 export { default as IconPlayStore } from './playstore';
 export { default as IconStar } from './star';
+export { default as IconSun } from './sun';
 export { default as IconTwitter } from './twitter';

--- a/src/components/icons/moon.js
+++ b/src/components/icons/moon.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const IconMoon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-moon">
+    <title>Dark Mode</title>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+);
+
+export default IconMoon;

--- a/src/components/icons/sun.js
+++ b/src/components/icons/sun.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const IconSun = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-sun">
+    <title>Light Mode</title>
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+);
+
+export default IconSun;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,6 +7,7 @@ export { default as Side } from './side';
 export { default as Social } from './social';
 export { default as Email } from './email';
 export { default as Footer } from './footer';
+export { default as ThemeToggle } from './themeToggle';
 export { default as Hero } from './sections/hero';
 export { default as About } from './sections/about';
 export { default as Jobs } from './sections/jobs';

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { ThemeProvider } from 'styled-components';
 import { Head, Loader, Nav, Social, Email, Footer } from '@components';
 import { GlobalStyle, theme } from '@styles';
+import { ThemeProvider as CustomThemeProvider } from '@context/ThemeContext';
 
 const StyledContent = styled.div`
   display: flex;
@@ -51,28 +52,30 @@ const Layout = ({ children, location }) => {
       <Head />
 
       <div id="root">
-        <ThemeProvider theme={theme}>
-          <GlobalStyle />
+        <CustomThemeProvider>
+          <ThemeProvider theme={theme}>
+            <GlobalStyle />
 
-          <a className="skip-to-content" href="#content">
-            Skip to Content
-          </a>
+            <a className="skip-to-content" href="#content">
+              Skip to Content
+            </a>
 
-          {isLoading && isHome ? (
-            <Loader finishLoading={() => setIsLoading(false)} />
-          ) : (
-            <StyledContent>
-              <Nav isHome={isHome} />
-              <Social isHome={isHome} />
-              <Email isHome={isHome} />
+            {isLoading && isHome ? (
+              <Loader finishLoading={() => setIsLoading(false)} />
+            ) : (
+              <StyledContent>
+                <Nav isHome={isHome} />
+                <Social isHome={isHome} />
+                <Email isHome={isHome} />
 
-              <div id="content">
-                {children}
-                <Footer />
-              </div>
-            </StyledContent>
-          )}
-        </ThemeProvider>
+                <div id="content">
+                  {children}
+                  <Footer />
+                </div>
+              </StyledContent>
+            )}
+          </ThemeProvider>
+        </CustomThemeProvider>
       </div>
     </>
   );

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -33,21 +33,11 @@ const StyledHeader = styled.header`
 
   @media (prefers-reduced-motion: no-preference) {
     ${props =>
-    props.scrollDirection === 'up' &&
-      !props.scrolledToTop &&
+    !props.scrolledToTop &&
       css`
         height: var(--nav-scroll-height);
         transform: translateY(0px);
         background-color: var(--navy);
-        box-shadow: 0 10px 30px -10px var(--navy-shadow);
-      `};
-
-    ${props =>
-    props.scrollDirection === 'down' &&
-      !props.scrolledToTop &&
-      css`
-        height: var(--nav-scroll-height);
-        transform: translateY(calc(var(--nav-scroll-height) * -1));
         box-shadow: 0 10px 30px -10px var(--navy-shadow);
       `};
   }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -6,7 +6,7 @@ import styled, { css } from 'styled-components';
 import { navLinks } from '@config';
 import { loaderDelay } from '@utils';
 import { useScrollDirection, usePrefersReducedMotion } from '@hooks';
-import { Menu } from '@components';
+import { Menu, ThemeToggle } from '@components';
 import { IconLogo, IconHex } from '@components/icons';
 
 const StyledHeader = styled.header`
@@ -17,12 +17,12 @@ const StyledHeader = styled.header`
   padding: 0px 50px;
   width: 100%;
   height: var(--nav-height);
-  background-color: rgba(10, 25, 47, 0.85);
+  background-color: var(--navy);
   filter: none !important;
   pointer-events: auto !important;
   user-select: auto !important;
   backdrop-filter: blur(10px);
-  transition: var(--transition);
+  transition: var(--transition), background-color 0.3s ease;
 
   @media (max-width: 1080px) {
     padding: 0 40px;
@@ -38,7 +38,7 @@ const StyledHeader = styled.header`
       css`
         height: var(--nav-scroll-height);
         transform: translateY(0px);
-        background-color: rgba(10, 25, 47, 0.85);
+        background-color: var(--navy);
         box-shadow: 0 10px 30px -10px var(--navy-shadow);
       `};
 
@@ -228,6 +228,7 @@ const Nav = ({ isHome }) => {
                   ))}
               </ol>
               <div>{ResumeLink}</div>
+              <ThemeToggle />
             </StyledLinks>
 
             <Menu />
@@ -262,6 +263,17 @@ const Nav = ({ isHome }) => {
                   <CSSTransition classNames={fadeDownClass} timeout={timeout}>
                     <div style={{ transitionDelay: `${isHome ? navLinks.length * 100 : 0}ms` }}>
                       {ResumeLink}
+                    </div>
+                  </CSSTransition>
+                )}
+              </TransitionGroup>
+
+              <TransitionGroup component={null}>
+                {isMounted && (
+                  <CSSTransition classNames={fadeDownClass} timeout={timeout}>
+                    <div
+                      style={{ transitionDelay: `${isHome ? (navLinks.length + 1) * 100 : 0}ms` }}>
+                      <ThemeToggle />
                     </div>
                   </CSSTransition>
                 )}

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -81,9 +81,12 @@ const StyledPic = styled.div`
     .img {
       position: relative;
       border-radius: var(--border-radius);
-      mix-blend-mode: multiply;
       filter: grayscale(100%) contrast(1);
       transition: var(--transition);
+
+      [data-theme='dark'] & {
+        mix-blend-mode: multiply;
+      }
     }
 
     &:before,
@@ -100,8 +103,14 @@ const StyledPic = styled.div`
     &:before {
       top: 0;
       left: 0;
-      background-color: var(--navy);
-      mix-blend-mode: screen;
+      background-color: var(--green);
+      opacity: 0.3;
+
+      [data-theme='dark'] & {
+        background-color: var(--navy);
+        mix-blend-mode: screen;
+        opacity: 1;
+      }
     }
 
     &:after {

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -283,21 +283,34 @@ const StyledProject = styled.li`
         bottom: 0;
         z-index: 3;
         transition: var(--transition);
-        background-color: var(--navy);
-        mix-blend-mode: screen;
+        background-color: var(--green);
+        opacity: 0.3;
+
+        [data-theme='dark'] & {
+          background-color: var(--navy);
+          mix-blend-mode: screen;
+          opacity: 1;
+        }
       }
     }
 
     .img {
       border-radius: var(--border-radius);
-      mix-blend-mode: multiply;
       filter: grayscale(100%) contrast(1) brightness(90%);
+
+      [data-theme='dark'] & {
+        mix-blend-mode: multiply;
+      }
 
       @media (max-width: 768px) {
         object-fit: cover;
         width: auto;
         height: 100%;
-        filter: grayscale(100%) contrast(1) brightness(50%);
+        filter: grayscale(100%) contrast(1) brightness(80%);
+
+        [data-theme='dark'] & {
+          filter: grayscale(100%) contrast(1) brightness(50%);
+        }
       }
     }
   }

--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTheme } from '@context/ThemeContext';
+import { IconSun, IconMoon } from '@components/icons';
+
+const StyledThemeToggle = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  border: 1px solid var(--green);
+  border-radius: var(--border-radius);
+  padding: 10px;
+  margin-left: 15px;
+  color: var(--green);
+  cursor: pointer;
+  transition: var(--transition);
+  width: 42px;
+  height: 42px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    transition: var(--transition);
+  }
+
+  &:hover,
+  &:focus {
+    outline: none;
+    background-color: var(--green-tint);
+    transform: translateY(-2px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`;
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <StyledThemeToggle
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
+      {theme === 'dark' ? <IconSun /> : <IconMoon />}
+    </StyledThemeToggle>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -23,16 +23,23 @@ const StyledThemeToggle = styled.button`
     height: 20px;
     transition: var(--transition);
   }
-
-  &:hover,
-  &:focus {
-    outline: none;
+  &:hover {
     box-shadow: 4px 4px 0 0 var(--green);
     transform: translate(-5px, -5px);
   }
 
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--green);
+    outline-offset: 3px;
+  }
+
   &:active {
     transform: translate(0, 0);
+    box-shadow: none;
   }
 `;
 

--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -27,12 +27,12 @@ const StyledThemeToggle = styled.button`
   &:hover,
   &:focus {
     outline: none;
-    background-color: var(--green-tint);
-    transform: translateY(-2px);
+    box-shadow: 4px 4px 0 0 var(--green);
+    transform: translate(-5px, -5px);
   }
 
   &:active {
-    transform: translateY(0);
+    transform: translate(0, 0);
   }
 `;
 

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,48 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
+
+const ThemeContext = createContext();
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('dark');
+
+  useEffect(() => {
+    // Load theme from localStorage or use system preference
+    const savedTheme = localStorage.getItem('theme');
+
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    } else {
+      // Check system preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initialTheme = prefersDark ? 'dark' : 'light';
+      setTheme(initialTheme);
+      document.documentElement.setAttribute('data-theme', initialTheme);
+      localStorage.setItem('theme', initialTheme);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};
+
+ThemeProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ThemeContext;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -79,6 +79,7 @@ const GlobalStyle = createGlobalStyle`
     font-family: var(--font-sans);
     font-size: var(--fz-xl);
     line-height: 1.3;
+    transition: background-color 0.3s ease, color 0.3s ease;
 
     @media (max-width: 480px) {
       font-size: var(--fz-lg);

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -48,6 +48,21 @@ const variables = css`
     --ham-after-active: bottom 0.1s ease-out,
       transform 0.22s cubic-bezier(0.215, 0.61, 0.355, 1) 0.12s;
   }
+
+  [data-theme='light'] {
+    --dark-navy: #f8f9fa;
+    --navy: #ffffff;
+    --light-navy: #e9ecef;
+    --lightest-navy: #dee2e6;
+    --navy-shadow: rgba(0, 0, 0, 0.1);
+    --dark-slate: #6c757d;
+    --slate: #495057;
+    --light-slate: #343a40;
+    --lightest-slate: #212529;
+    --white: #000000;
+    --green: #00a67d;
+    --green-tint: rgba(0, 166, 125, 0.1);
+  }
 `;
 
 export default variables;


### PR DESCRIPTION
- Light/dark theme toggle: Adds a theme toggle in the navigation bar powered by ThemeContext, persisting the user’s preference in localStorage.
- Brutalist hover styling: Updates the toggle’s hover state to use a more brutalist offset shadow effect.
- Pressed-state fix: Ensures the toggle button no longer stays visually “pressed” after being clicked.
- Pinned navigation bar: Adjusts the navigation so it stays fixed at the top of the viewport while scrolling.